### PR TITLE
Port to candle-core 0.10.1 / cudarc 0.19

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [dependencies]
-candle = { version = "*", package = "candle-core", features = ["cuda"]}
+candle = { version = "=0.10.1", package = "candle-core", features = ["cuda"] }
 half = { version = "2.3.1", features = ["num-traits"] }
 
 [build-dependencies]
@@ -19,4 +19,4 @@ bindgen_cuda = "0.1.1"
 
 [dev-dependencies]
 anyhow = { version = "1", features = ["backtrace"] }
-candle-nn = { version = "0.3.0", features = ["cuda"] }
+candle-nn = { version = "=0.10.1", features = ["cuda"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,10 +102,21 @@ fn apply_rotary_<
     let query_stride = q_l.stride()[0];
     let key_stride = k_l.stride()[0];
 
-    let q_ptr = *q.device_ptr() as *const core::ffi::c_void;
-    let k_ptr = *k.device_ptr() as *const core::ffi::c_void;
-    let cc_ptr = *cc.device_ptr() as *const core::ffi::c_void;
-    let sc_ptr = *sc.device_ptr() as *const core::ffi::c_void;
+    // cudarc 0.19 device_ptr() takes a CudaStream and returns (u64, guard).
+    let dev = match query.device() {
+        Device::Cuda(d) => d,
+        _ => candle::bail!("query must be on a cuda device"),
+    };
+    let stream = dev.cuda_stream();
+
+    let (q_ptr, _q_g) = q.device_ptr(&stream);
+    let (k_ptr, _k_g) = k.device_ptr(&stream);
+    let (cc_ptr, _cc_g) = cc.device_ptr(&stream);
+    let (sc_ptr, _sc_g) = sc.device_ptr(&stream);
+    let q_ptr = q_ptr as *const core::ffi::c_void;
+    let k_ptr = k_ptr as *const core::ffi::c_void;
+    let cc_ptr = cc_ptr as *const core::ffi::c_void;
+    let sc_ptr = sc_ptr as *const core::ffi::c_void;
 
     let neox = if is_neox { 1 } else { 0 };
 


### PR DESCRIPTION
Updates the crate to build against `candle-core 0.10.1` (matching the current spiceai candle fork at rev `fab4da81`) and the corresponding `cudarc 0.19` API.

## Cargo.toml

- Pin candle to `=0.10.1`. The previous `candle = { version = "*", package = "candle-core" }` silently resolved to `candle-core 0.8.4` from crates.io whenever a downstream workspace also had candle-core 0.10.x in its graph, producing distinct `CudaSlice` / `CudaView` types across crate boundaries and breaking `DevicePtr` trait bounds.

## `src/lib.rs` — cudarc 0.19 / candle 0.10 API migration

- `CudaDevice::cuda_device()` was renamed to `cuda_stream()`; `DevicePtr` lookups now go through the stream.
- `DevicePtr::device_ptr(&self, &stream)` replaces the old `device_ptr(&self)`.
- `CudaDevice::alloc::<T>(len)` already returns `candle_core::Result<CudaSlice<T>>` in 0.10, so the `.w()?` wrappers are redundant.
- Drop the now-unused `use candle::cuda_backend::WrapErr;` import.

## Validation

- Consumer workspace (`spiceai/spiceai`, branch `lukim/lockstep-candle-0.10.1-mistral-0.8.0`) builds cleanly: `cargo build --release --features cuda` on CUDA 12.6 with `CUDA_COMPUTE_CAP=90`.
